### PR TITLE
Add platformio library.json manifest files

### DIFF
--- a/ftduino/libraries/Ftduino/library.json
+++ b/ftduino/libraries/Ftduino/library.json
@@ -1,0 +1,18 @@
+{
+    "name": "Ftduino",
+    "description": "Use this library with the ftDuino board. It allows easy controlling of models built with the fischertechnik construction toy. For more information refer to https://github.com/harbaum/ftduino/blob/master/manual.pdf",
+    "keywords": "fischertechnik, IO, construction, motors",
+    "authors": {
+        "name": "Till Harbaum",
+        "email": "info@ftduino.de",
+        "url": "https://ftduino.de"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/harbaum/ftduino.git"
+    },
+    "version": "0.0.11",
+    "include": "ftduino/libraries/Ftduino",
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}

--- a/ftduino/libraries/FtduinoSimple/library.json
+++ b/ftduino/libraries/FtduinoSimple/library.json
@@ -1,0 +1,18 @@
+{
+    "name": "FtduinoSimple",
+    "description": "Simpler and smaller version of the Ftduino library. Use only with ftDuino board. For more information refer to https://github.com/harbaum/ftduino/blob/master/manual.pdf",
+    "keywords": "fischertechnik, IO, construction, motors, simple, lightweight",
+    "authors": {
+        "name": "Till Harbaum",
+        "email": "info@ftduino.de",
+        "url": "https://ftduino.de"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/harbaum/ftduino.git"
+    },
+    "version": "0.0.11",
+    "include": "ftduino/libraries/FtduinoSimple",
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}


### PR DESCRIPTION
These files allow to register the library at the platfomio library registry.
Documentation: http://docs.platformio.org/en/latest/librarymanager/config.html
Registering a library: https://docs.platformio.org/en/latest/userguide/lib/cmd_register.html

This would complete the support of ftDuino within platfomio.

See also: https://github.com/platformio/platform-atmelavr/pull/110

Note that the version number has to get increased by each new release. It is recommended to specify a version number so that users do not receive updates after each new commit to the repo.