### PR TITLE
Define tmp file to make it work with arduino-cli

### DIFF
--- a/ftduino/platform.txt
+++ b/ftduino/platform.txt
@@ -34,3 +34,7 @@ tools.avrdude.bootloader.pattern="{cmd.path}" "-C{config.path}" {bootloader.verb
 # - from numeric vendor ID, set to Unknown otherwise
 build.usb_manufacturer="Unknown"
 build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'
+
+
+recipe.output.tmp_file={build.project_name}.hex
+recipe.output.save_file={build.project_name}.{build.variant}.hex


### PR DESCRIPTION
Arduino-cli expects the value `recipe.output.tmp_file` to be set.